### PR TITLE
Rename ApplicationWindow to LuneOSWindow

### DIFF
--- a/qml/main.qml
+++ b/qml/main.qml
@@ -26,7 +26,7 @@ import QtQuick.Layouts 1.0
 
 import LunaNext.Common 0.1
 import LuneOS.Service 1.0
-import LuneOS.Application 1.0 as LuneOS
+import LuneOS.Application 1.0
 
 Item {
     id: root
@@ -43,7 +43,7 @@ Item {
         var params = JSON.parse(launchParams);
 
         if (params.mode && params.mode === "first-use") {
-            simPinWindowId.type = typeof application === "undefined" ? 0 : LuneOS.ApplicationWindow.Pin;
+            simPinWindowId.type = typeof application === "undefined" ? 0 : LuneOSWindow.Pin;
             // PIN window will now open automatically when the PIN is required
             return;
         }

--- a/qml/views/IncomingCallAlert.qml
+++ b/qml/views/IncomingCallAlert.qml
@@ -20,7 +20,7 @@ import QtMultimedia 5.5
 
 import LunaNext.Common 0.1
 import LunaNext.Compositor 0.1
-import LuneOS.Application 1.0 as LuneOS
+import LuneOS.Application 1.0
 
 import org.nemomobile.voicecall 1.0
 
@@ -30,7 +30,7 @@ import "../services"
 import "../model"
 import "../services/IncomingCallsService.js" as IncomingCallsService
 
-LuneOS.ApplicationWindow {
+LuneOSWindow {
     id: incomingCallAlert
 
     property ContactsModel contacts;
@@ -42,7 +42,7 @@ LuneOS.ApplicationWindow {
     width: Settings.displayWidth
     height: Units.gu(24)
 
-    type: LuneOS.ApplicationWindow.PopupAlert
+    type: LuneOSWindow.PopupAlert
     color: "transparent"
 
     Audio {

--- a/qml/views/IncomingUSSDAlert.qml
+++ b/qml/views/IncomingUSSDAlert.qml
@@ -21,13 +21,13 @@ import QtQuick.Controls.Styles 1.1
 
 import LunaNext.Common 0.1
 import LunaNext.Compositor 0.1
-import LuneOS.Application 1.0 as LuneOS
+import LuneOS.Application 1.0
 
 import org.nemomobile.voicecall 1.0
 
 import "../services"
 
-LuneOS.ApplicationWindow {
+LuneOSWindow {
     id: incomingUSSDAlert
 
     property TelephonyManager telephonyManager;
@@ -35,7 +35,7 @@ LuneOS.ApplicationWindow {
     width: Settings.displayWidth
     height: Units.gu(24)
 
-    type: LuneOS.ApplicationWindow.PopupAlert
+    type: LuneOSWindow.PopupAlert
     color: "transparent"
 
     Connections {

--- a/qml/views/PhoneWindow.qml
+++ b/qml/views/PhoneWindow.qml
@@ -27,7 +27,7 @@ import QtQuick.Layouts 1.0
 import LunaNext.Common 0.1
 import LuneOS.Application 1.0
 
-ApplicationWindow {
+LuneOSWindow {
     id: phoneWindowId
 
     property CallHistory historyModel

--- a/qml/views/SimPinWindow.qml
+++ b/qml/views/SimPinWindow.qml
@@ -21,12 +21,12 @@ import QtQuick.Layouts 1.0
 import QtQuick.Controls.Styles 1.1
 import LunaNext.Common 0.1
 import LuneOS.Service 1.0
-import LuneOS.Application 1.0 as LuneOS
+import LuneOS.Application 1.0
 import MeeGo.QOfono 0.2
 import "../services"
 import "../services/PinTypes.js" as PinTypes
 
-LuneOS.ApplicationWindow {
+LuneOSWindow {
     id: simPinWindow
 
     width: Settings.displayWidth


### PR DESCRIPTION
There's already a QML type "ApplicationWindow" defined in QtQuick.Controls.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>