### PR TITLE
appinfo.json: Fix LS2 permission error

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -10,6 +10,6 @@
 	"icon": "icon.png",
 	"uiRevision": "2",
 	"keywords": [ "Dial" ],
-	"requiredPermissions": ["application.operation", "audio.operation", "audio.management", "database.operation", "luna-sysmgr.operation", "networkconnection.query", "networkconnection.management", "systemsettings.management", "systemsettings.query", "telephony.query", "wifi.query", "wifi.management"]
+	"requiredPermissions": ["application.operation", "audio.operation", "audio.management", "database.operation", "luna-sysmgr.operation", "networkconnection.query", "networkconnection.management", "systemsettings.management", "systemsettings.query", "telephony.query", "tweaks-service.operation", "wifi.query", "wifi.management"]
 }
 


### PR DESCRIPTION
Fixes:

pinephonepro ports.service.tweaks.prefs[892]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"org.webosports.app.phone-959","CATEGORY":"/","METHOD":"get"} Service security groups don't allow method call.